### PR TITLE
github-old-header 2.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# GitHub Old Header [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/github-old-header.svg)](https://www.npmjs.com/package/github-old-header) [![Downloads](https://img.shields.io/npm/dt/github-old-header.svg)](https://www.npmjs.com/package/github-old-header) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# GitHub Old Header
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/github-old-header.svg)](https://www.npmjs.com/package/github-old-header) [![Downloads](https://img.shields.io/npm/dt/github-old-header.svg)](https://www.npmjs.com/package/github-old-header) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Brings the old header links back.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-old-header",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Brings the old header links back.",
   "main": "lib/index.js",
   "scripts": {
@@ -56,6 +56,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
